### PR TITLE
Absolute url for import.html

### DIFF
--- a/import.js
+++ b/import.js
@@ -1,1 +1,1 @@
-document.getElementsByTagName('head')[0].innerHTML += '<link rel="import" href="elements/import.html">';
+document.getElementsByTagName('head')[0].innerHTML += '<link rel="import" href="/elements/import.html">';


### PR DESCRIPTION
In case you use a router and want to render something that's not on the root you need an absolute path.
For example: /blog/posts/1
