### PR TITLE
_wrapAsync changed name to wrapAsync

### DIFF
--- a/polymer.js
+++ b/polymer.js
@@ -7,7 +7,7 @@ Bower = {};
 
 // Wrap every asynchronus bower command with `Meteor._wrapAsync`
 _.forEach(bowerCommands, function (command) {
-  Bower[command] = Meteor._wrapAsync(function() {
+  Bower[command] = Meteor.wrapAsync(function() {
     argsArray = _.toArray(arguments);
     var callback = argsArray.pop();
     bower.commands[command]


### PR DESCRIPTION
Just simple name change to work with the newest version of Meteor without error.
