### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#Meteor-Polymer
+# Meteor-Polymer
 
 Add the magic of web components and [Polymer](http://polymer-project.org) to [Meteor](http://meteor.com)!
 
-##About
-###This package does not include polymer-elements!!! Follow directions below to include all polymer elements.
+## About
+### This package does not include polymer-elements!!! Follow directions below to include all polymer elements.
 This package adds the base functionality of Polymer. There are no elements included in this project. This was done so that end users have the option to use their own blend of elements without the overhead of also providing polymer elements. If you want to include [core-elements and paper-elements](http://www.polymer-project.org/docs/elements/) simply run:
 
 ```bash
@@ -12,7 +12,7 @@ meteor add ecwyne:polymer-elements
 
 This will add the [ecwyne:polymer-elements](http://github.com/ecwyne/meteor-polymer-elements) package.
 
-##How to Install
+## How to Install
 
 ```bash
 meteor add ecwyne:polymer


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
